### PR TITLE
version discrepancy: bin/sw -> bin/sw2.prod etc.

### DIFF
--- a/run
+++ b/run
@@ -4,6 +4,6 @@ if [ "$#" -ne 4 ]; then
     echo "Usage: ./sw data/[mldatapath] [chunk_size] [time_step] [end_time]"
 else
     mkdir -p resdata/$1-dt$3
-    ( cd resdata/$1-dt$3 ; ln -s ../../data ; ../../bin/sw data/$1 $2 $3 $4 >& info.txt )
+    ( cd resdata/$1-dt$3 ; ln -s ../../data ; ../../bin/sw2.prod data/$1 $2 $3 $4 >& info.txt )
     cat resdata/$1-dt$3/info.txt
 fi

--- a/runmpi
+++ b/runmpi
@@ -4,6 +4,6 @@ if [ "$#" -ne 4 ]; then
     echo "Usage: ./sw data/[mldatapath] [chunk_size] [time_step] [end_time]"
 else
     mkdir -p resdata/$1-dt$3
-    ( cd resdata/$1-dt$3 ; ln -s ../../data ; mpirun -n 4 ../../bin/swmpi data/$1 $2 $3 $4 >& info.txt )
+    ( cd resdata/$1-dt$3 ; ln -s ../../data ; mpirun -n 4 ../../bin/swmpi2.prod data/$1 $2 $3 $4 >& info.txt )
     cat resdata/$1-dt$3/info.txt
 fi

--- a/test.sh
+++ b/test.sh
@@ -37,7 +37,7 @@ fi
 ### 0: COMPILE
 
 if [[ ${TESTS} == *0* ]]; then
-  make bin/sw
+  make bin/sw2.prod
 fi
 
 

--- a/testga.sh
+++ b/testga.sh
@@ -33,7 +33,7 @@ fi
 ### 0: COMPILE
 
 if [[ ${TESTS} == *0* ]]; then
-  make bin/sw
+  make bin/sw2.prod
 fi
 
 

--- a/testmpi.sh
+++ b/testmpi.sh
@@ -37,7 +37,7 @@ fi
 ### 0: COMPILE
 
 if [[ ${TESTS} == *0* ]]; then
-  make bin/swmpi
+  make bin/swmpi2.prod
 fi
 
 


### PR DESCRIPTION
Hej,

I found a tiny mistake in rbf-sw code which might get a new user (like me :-)) a bit confused. The problem is that the files {test.sh, testmpi.sh, testga.sh, run, runmpi} were not updated according to the latest version of the other files.

For example, in test.sh the line
make bin/sw,

should be replaced by (I think):
make bin/sw2.prod.

Otherwise some tests don't work because there is no "bin/sw" rule in the Makefile. After this fix one can produce the pretty test plots.

Best,
Igor
